### PR TITLE
Relax net-ldap dependency.

### DIFF
--- a/oa-enterprise/oa-enterprise.gemspec
+++ b/oa-enterprise/oa-enterprise.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/omniauth/version', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.add_dependency 'addressable', '~> 2.2'
-  gem.add_dependency 'net-ldap', '~> 0.2.2'
+  gem.add_dependency 'net-ldap', '>= 0.2.2'
   gem.add_dependency 'nokogiri', '~> 1.5'
   gem.add_dependency 'oa-core', OmniAuth::Version::STRING
   gem.add_dependency 'pyu-ruby-sasl', '~> 0.0.3.1'


### PR DESCRIPTION
Because there are more modern versions that help a bunch of problems.

And also because we're not using omniauth for ldap authentication, and this gem is blocking us from upgrade.

We fix the required net-ldap version in github/github.

/cc @github/ldap
